### PR TITLE
feat: allow more markdown file-extensions than md

### DIFF
--- a/src/parser/parser.ts
+++ b/src/parser/parser.ts
@@ -33,8 +33,10 @@ export const pathHeading = (path: string) => `# \`${path.replace(homedir(), '~')
 export default function parse(src: string, path?: string) {
     let md = src;
 
+    let mdEndings = ['markdown', 'md', 'mdown', 'mdwn', 'mkd', 'mkdn']
+
     const fileEnding = path?.split('.')?.at(-1);
-    if (fileEnding && fileEnding !== 'md') {
+    if (fileEnding && ! mdEndings.includes(fileEnding)) {
         md = `${pathHeading(path!)}\n\n\`\`\`${fileEnding}\n${src}\n\`\`\``;
     }
 


### PR DESCRIPTION
Related issue: https://github.com/jannis-baum/vivify/issues/29