### PR TITLE
feat: add filetype icons

### DIFF
--- a/src/routes/viewer.ts
+++ b/src/routes/viewer.ts
@@ -20,10 +20,10 @@ const pageTitle = (path: string) => {
     else return join(basename(dirname(path)), basename(path));
 };
 
-const dirListItem = (item: Dirent) => {
+const dirListItem = (item: Dirent, path: string) => {
     return `<li class="dir-list-${
         item.isDirectory() ? 'directory' : 'file'
-    }"><a href="/viewer${join(item.path, item.name)}">${item.name}</a></li>`;
+    }"><a href="/viewer${join(path, item.name)}">${item.name}</a></li>`;
 };
 
 router.get(/.*/, async (req: Request, res: Response) => {
@@ -35,7 +35,7 @@ router.get(/.*/, async (req: Request, res: Response) => {
             if (lstatSync(path).isDirectory()) {
                 const list = readdirSync(path, { withFileTypes: true })
                     .sort((a, b) => +b.isDirectory() - +a.isDirectory())
-                    .map((item) => dirListItem(item))
+                    .map((item) => dirListItem(item, path))
                     .join('\n');
                 body = parse(`${pathHeading(path)}\n\n<ul class="dir-list">\n${list}\n</ul>`);
             } else {

--- a/src/routes/viewer.ts
+++ b/src/routes/viewer.ts
@@ -34,6 +34,7 @@ router.get(/.*/, async (req: Request, res: Response) => {
         try {
             if (lstatSync(path).isDirectory()) {
                 const list = readdirSync(path, { withFileTypes: true })
+                    .sort((a, b) => +b.isDirectory() - +a.isDirectory())
                     .map((item) => formatByFileType(item))
                     .join('\n');
                 body = parse(`${pathHeading(path)}\n\n${list}`);

--- a/src/routes/viewer.ts
+++ b/src/routes/viewer.ts
@@ -21,9 +21,14 @@ const pageTitle = (path: string) => {
 };
 
 const formatByFileType = (item: Dirent) => {
-    const link = (label: string) => `- [${label}](/viewer${join(item.path, item.name)})`;
-    if (item.isDirectory()) return link(`📁 \`${item.name}/\``);
-    return link(`📄 \`${item.name}\``);
+    const link = (label: string, classSuffix: string) =>
+        `<li class="dir-list-${classSuffix}"><a href="/viewer${join(
+            item.path,
+            item.name,
+        )}">${label}</a></li>`;
+
+    if (item.isDirectory()) return link(`${item.name}/`, 'directory');
+    return link(item.name, 'file');
 };
 
 router.get(/.*/, async (req: Request, res: Response) => {

--- a/src/routes/viewer.ts
+++ b/src/routes/viewer.ts
@@ -21,8 +21,9 @@ const pageTitle = (path: string) => {
 };
 
 const formatByFileType = (item: Dirent) => {
-    if (item.isDirectory()) return `${item.name}/`;
-    return item.name;
+    const link = (label: string) => `- [${label}](/viewer${join(item.path, item.name)})`;
+    if (item.isDirectory()) return link(`📁 \`${item.name}/\``);
+    return link(`📄 \`${item.name}\``);
 };
 
 router.get(/.*/, async (req: Request, res: Response) => {
@@ -34,7 +35,6 @@ router.get(/.*/, async (req: Request, res: Response) => {
             if (lstatSync(path).isDirectory()) {
                 const list = readdirSync(path, { withFileTypes: true })
                     .map((item) => formatByFileType(item))
-                    .map((item) => `- [\`${item}\`](/viewer${join(path, item)})`)
                     .join('\n');
                 body = parse(`${pathHeading(path)}\n\n${list}`);
             } else {

--- a/src/routes/viewer.ts
+++ b/src/routes/viewer.ts
@@ -42,7 +42,7 @@ router.get(/.*/, async (req: Request, res: Response) => {
                     .sort((a, b) => +b.isDirectory() - +a.isDirectory())
                     .map((item) => formatByFileType(item))
                     .join('\n');
-                body = parse(`${pathHeading(path)}\n\n${list}`);
+                body = parse(`${pathHeading(path)}\n\n<ul class="dir-list">\n${list}\n</ul>`);
             } else {
                 const data = readFileSync(path);
                 const type = getMimeFromPath(path);

--- a/src/routes/viewer.ts
+++ b/src/routes/viewer.ts
@@ -20,15 +20,10 @@ const pageTitle = (path: string) => {
     else return join(basename(dirname(path)), basename(path));
 };
 
-const formatByFileType = (item: Dirent) => {
-    const link = (label: string, classSuffix: string) =>
-        `<li class="dir-list-${classSuffix}"><a href="/viewer${join(
-            item.path,
-            item.name,
-        )}">${label}</a></li>`;
-
-    if (item.isDirectory()) return link(`${item.name}/`, 'directory');
-    return link(item.name, 'file');
+const dirListItem = (item: Dirent) => {
+    return `<li class="dir-list-${
+        item.isDirectory() ? 'directory' : 'file'
+    }"><a href="/viewer${join(item.path, item.name)}">${item.name}</a></li>`;
 };
 
 router.get(/.*/, async (req: Request, res: Response) => {
@@ -40,7 +35,7 @@ router.get(/.*/, async (req: Request, res: Response) => {
             if (lstatSync(path).isDirectory()) {
                 const list = readdirSync(path, { withFileTypes: true })
                     .sort((a, b) => +b.isDirectory() - +a.isDirectory())
-                    .map((item) => formatByFileType(item))
+                    .map((item) => dirListItem(item))
                     .join('\n');
                 body = parse(`${pathHeading(path)}\n\n<ul class="dir-list">\n${list}\n</ul>`);
             } else {

--- a/src/routes/viewer.ts
+++ b/src/routes/viewer.ts
@@ -1,5 +1,5 @@
 import { execSync } from 'child_process';
-import { lstatSync, readdirSync, readFileSync } from 'fs';
+import { Dirent, lstatSync, readdirSync, readFileSync } from 'fs';
 import { basename, dirname, join } from 'path';
 
 import { Request, Response, Router } from 'express';
@@ -20,6 +20,11 @@ const pageTitle = (path: string) => {
     else return join(basename(dirname(path)), basename(path));
 };
 
+const formatByFileType = (item: Dirent) => {
+    if (item.isDirectory()) return `${item.name}/`;
+    return item.name;
+};
+
 router.get(/.*/, async (req: Request, res: Response) => {
     const path = res.locals.filepath;
 
@@ -27,7 +32,8 @@ router.get(/.*/, async (req: Request, res: Response) => {
     if (!body) {
         try {
             if (lstatSync(path).isDirectory()) {
-                const list = readdirSync(path)
+                const list = readdirSync(path, { withFileTypes: true })
+                    .map((item) => formatByFileType(item))
                     .map((item) => `- [\`${item}\`](/viewer${join(path, item)})`)
                     .join('\n');
                 body = parse(`${pathHeading(path)}\n\n${list}`);

--- a/static/style.css
+++ b/static/style.css
@@ -71,7 +71,11 @@ input.task-list-item-checkbox {
     transform: translateX(-1.44rem);
 }
 
-li[class^='dir-list-'] { list-style: none; }
+ul.dir-list { padding: 0 }
+li[class^='dir-list-'] {
+    list-style: none;
+    margin: 0.25rem 0;
+}
 li[class^='dir-list-']:before { margin-right: 0.5rem; }
 li.dir-list-directory:before { content: '📁' }
 li.dir-list-file:before { content: '📄' }

--- a/static/style.css
+++ b/static/style.css
@@ -71,6 +71,11 @@ input.task-list-item-checkbox {
     transform: translateX(-1.44rem);
 }
 
+li[class^='dir-list-'] { list-style: none; }
+li[class^='dir-list-']:before { margin-right: 0.5rem; }
+li.dir-list-directory:before { content: '📁' }
+li.dir-list-file:before { content: '📄' }
+
 /* --------------------------------------------------------------------------
  * IMAGES ------------------------------------------------------------------- */
 img, svg { max-width: 100%; }


### PR DESCRIPTION
Refers to discussion in comments here: https://github.com/jannis-baum/vivify/issues/27#issuecomment-1805328693

Motivation: no more ambiguity whether an item is a regular file or a directory

### Thoughts about symlinks

I was gonna also add trailing `@` for symbolic links, the same way as `ls -F` does, but actually symbolic links don't really work at all (you can't resolve the path by clicking on it) so if we wanna look into those, that's a separate issue.

My take about that would be: if resolving a symlink path adds too much complexity, maybe not worth adding. Otherwise, sure.

### Didn't add separate dir color at this time

The trailing slash was a great point to start, it's fine by me if the entries are styled as a link (`<a>`) because that's what they literally are.


What do you think?