### PR TITLE
fix: various regex issues with filepath

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,17 +62,11 @@ following optional keys:
   ```
 - **`"pageTitle"`**\
   JavaScript code that will be evaluated to determine the viewer's page title.
-  Here, the variables
-  
-  - `path` (the full path),
-  - `basename` (the path's
-    [`basename`](https://nodejs.org/api/path.html#pathbasenamepath-suffix)), and
-  - `dirbasename` (the parent directory's `basename`)
-  
-  are defined according to the what the viewer is currently showing. If this
+  Here, the variable `components` is set to a string array of path components
+  for the current file, e.g. `['/', 'Users', 'you', 'file.txt']`. If this
   evaluation fails, the title will be *custom title error* and you will see the
-  error message on the page. The default title is ``
-  `${dirbasename}/${basename}` ``, e.g.  `my_dir/my_file`)
+  error message on the page. The default title is
+  `components.splice(-2).join('/')`, e.g.  `you/file.txt`
 
 Note that you need to have [`jq`](https://github.com/jqlang/jq) installed if you
 want to use a custom config file.

--- a/README.md
+++ b/README.md
@@ -65,8 +65,8 @@ following optional keys:
   Here, the variable `components` is set to a string array of path components
   for the current file, e.g. `['/', 'Users', 'you', 'file.txt']`. If this
   evaluation fails, the title will be *custom title error* and you will see the
-  error message on the page. The default title is
-  `components.splice(-2).join('/')`, e.g.  `you/file.txt`
+  error message on the page. The default title are the last two components
+  joined with the path separator, e.g.  `you/file.txt`
 
 Note that you need to have [`jq`](https://github.com/jqlang/jq) installed if you
 want to use a custom config file.

--- a/src/app.ts
+++ b/src/app.ts
@@ -21,10 +21,14 @@ process.env['VIV_PORT'] = process.env['VIV_PORT'] ?? '31622';
 const app = express();
 app.use(express.json());
 app.use((req, res, next) => {
-    res.locals.filepath = req.path
-        .replace(/^\/(viewer|health)/, '')
-        .replace(/^.*~/, homedir())
-        .replace(/\/$/, '');
+    const path = req.path.replace(/^\/(viewer|health)/, '')
+    if (path === "/") {
+        res.locals.filepath = "/"
+    } else {
+        res.locals.filepath = path
+            .replace(/^~/, homedir())
+            .replace(/(\/)+$/, '');
+    }
     next();
 });
 app.use('/static', express.static(path.join(__dirname, '../static')));

--- a/src/app.ts
+++ b/src/app.ts
@@ -21,12 +21,11 @@ process.env['VIV_PORT'] = process.env['VIV_PORT'] ?? '31622';
 const app = express();
 app.use(express.json());
 app.use((req, res, next) => {
-    const path = req.path.replace(/^\/(viewer|health)/, '');
-    if (path === '/') {
-        res.locals.filepath = '/';
-    } else {
-        res.locals.filepath = path.replace(/^~/, homedir()).replace(/(\/)+$/, '');
-    }
+    const path = req.path
+        .replace(/^\/(viewer|health)/, '')
+        .replace(/^~/, homedir())
+        .replace(/\/+$/, '');
+    res.locals.filepath = path === '' ? '/' : path;
     next();
 });
 app.use('/static', express.static(path.join(__dirname, '../static')));

--- a/src/app.ts
+++ b/src/app.ts
@@ -21,13 +21,11 @@ process.env['VIV_PORT'] = process.env['VIV_PORT'] ?? '31622';
 const app = express();
 app.use(express.json());
 app.use((req, res, next) => {
-    const path = req.path.replace(/^\/(viewer|health)/, '')
-    if (path === "/") {
-        res.locals.filepath = "/"
+    const path = req.path.replace(/^\/(viewer|health)/, '');
+    if (path === '/') {
+        res.locals.filepath = '/';
     } else {
-        res.locals.filepath = path
-            .replace(/^~/, homedir())
-            .replace(/(\/)+$/, '');
+        res.locals.filepath = path.replace(/^~/, homedir()).replace(/(\/)+$/, '');
     }
     next();
 });

--- a/src/routes/viewer.ts
+++ b/src/routes/viewer.ts
@@ -68,6 +68,9 @@ router.get(/.*/, async (req: Request, res: Response) => {
         body = `Error evaluating custom page title: ${error as string}`;
     }
 
+    // Edge case: when pageTitle is set as "basename", on root directory it's an empty string
+    if (title === '') title = '/';
+
     res.send(`
         <!DOCTYPE html>
         <html>

--- a/src/routes/viewer.ts
+++ b/src/routes/viewer.ts
@@ -14,7 +14,6 @@ const liveContent = new Map<string, string>();
 
 const pageTitle = (path: string) => {
     const comps = pcomponents(path);
-    console.log(comps, comps.slice(-2), pjoin(...comps.slice(-2)));
     if (config.pageTitle) {
         return eval(`
             const components = ${JSON.stringify(comps)};

--- a/src/routes/viewer.ts
+++ b/src/routes/viewer.ts
@@ -14,9 +14,10 @@ const liveContent = new Map<string, string>();
 
 const pageTitle = (path: string) => {
     const comps = pcomponents(path);
+    console.log(comps, comps.slice(-2), pjoin(...comps.slice(-2)));
     if (config.pageTitle) {
         return eval(`
-            const components = "${comps}";
+            const components = ${JSON.stringify(comps)};
             ${config.pageTitle};
         `);
     } else return pjoin(...comps.slice(-2));

--- a/src/utils/path.ts
+++ b/src/utils/path.ts
@@ -6,14 +6,14 @@ export const pmime = (path: string) => execSync(`file --mime-type -b '${path}'`)
 export const pcomponents = (path: string) => {
     const parsed = pparse(path);
     const components = new Array<string>();
-    // root
-    if (parsed.root !== '') components.push(parsed.root);
     // directory
     let dir = parsed.dir;
     while (dir !== '/' && dir !== '') {
-        components.push(pbasename(dir));
+        components.unshift(pbasename(dir));
         dir = pdirname(dir);
     }
+    // root
+    if (parsed.root !== '') components.unshift(parsed.root);
     // base
     if (parsed.base !== '') components.push(parsed.base);
     return components;

--- a/src/utils/path.ts
+++ b/src/utils/path.ts
@@ -1,0 +1,20 @@
+import { execSync } from 'child_process';
+import { basename as pbasename, dirname as pdirname, parse as pparse } from 'path';
+
+export const pmime = (path: string) => execSync(`file --mime-type -b '${path}'`).toString().trim();
+
+export const pcomponents = (path: string) => {
+    const parsed = pparse(path);
+    const components = new Array<string>();
+    // root
+    if (parsed.root !== '') components.push(parsed.root);
+    // directory
+    let dir = parsed.dir;
+    while (dir !== '/' && dir !== '') {
+        components.push(pbasename(dir));
+        dir = pdirname(dir);
+    }
+    // base
+    if (parsed.base !== '') components.push(parsed.base);
+    return components;
+};


### PR DESCRIPTION
Related: https://github.com/jannis-baum/vivify/issues/27#issuecomment-1809401423

Primarily fixes the bug that you can't view the root directory either by `viv /`, or traversing all the way to root with the parent-dir hidden button.

Fixes 2 other edge cases:
* (unrealistic) case, where you have a file named `hello~` in `/home` where the `~` should not be substituted
* repeating trailing slashes, such as `~/FooDirectory/////////` could be checked alongside removing a single trailing slash