### PR TITLE
fix: slightly indented first line of pre block

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -31,7 +31,10 @@ code {
     padding: 0.2rem;
     border-radius: 0.25rem;
 }
-pre > code { background-color: unset; }
+pre > code {
+    background-color: unset;
+    padding: unset;
+}
 
 /* --------------------------------------------------------------------------
  * LINKS -------------------------------------------------------------------- */


### PR DESCRIPTION
Close: https://github.com/jannis-baum/vivify/issues/38

@jannis-baum what you said here looks like it worked perfect:
> let's fix it in the CSS by `unset`ting the padding of `code`s in `pre`s like we do with the background color.