### PR TITLE
feat(#57): footnotes

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,9 +26,10 @@
     "markdown-it": "^13.0.1",
     "markdown-it-anchor": "^8.6.7",
     "markdown-it-emoji": "^2.0.2",
+    "markdown-it-footnote": "^4.0.0",
     "markdown-it-inject-linenumbers": "^0.3.0",
-    "markdown-it-texmath": "^1.0.0",
     "markdown-it-task-lists": "^2.1.1",
+    "markdown-it-texmath": "^1.0.0",
     "uuid": "^9.0.0",
     "ws": "^8.13.0"
   },

--- a/src/parser/parser.ts
+++ b/src/parser/parser.ts
@@ -20,6 +20,7 @@ mdit.use(anchor, {
 /* eslint-disable @typescript-eslint/no-var-requires */
 mdit.use(require('markdown-it-emoji'));
 mdit.use(require('markdown-it-task-lists'));
+mdit.use(require('markdown-it-footnote'));
 mdit.use(require('markdown-it-inject-linenumbers'));
 mdit.use(require('markdown-it-texmath'), {
     engine: require('katex'),

--- a/static/style.css
+++ b/static/style.css
@@ -124,6 +124,18 @@ hr {
 }
 
 /* --------------------------------------------------------------------------
+ * FOOTNOTE ----------------------------------------------------------------- */
+.footnotes-sep {
+    display: none;
+}
+section.footnotes {
+    font-size: 12px;
+    margin-top: 20px;
+    border-top: 0.2px solid #444;
+    color: #7d7d7d;
+}
+
+/* --------------------------------------------------------------------------
  * LIGHT MODE --------------------------------------------------------------- */
 @media (prefers-color-scheme: light) {
     html {
@@ -166,5 +178,10 @@ hr {
 
     hr {
         background-color: #d0d7de;
+    }
+
+    section.footnotes {
+        border-top: 0.2px solid #d8dee4;
+        color: #656d76;
     }
 }

--- a/static/style.css
+++ b/static/style.css
@@ -129,8 +129,8 @@ hr {
     display: none;
 }
 section.footnotes {
-    font-size: 12px;
-    margin-top: 20px;
+    font-size: 0.75rem;
+    margin-top: 1.25rem;
     border-top: 0.2px solid #444;
     color: #7d7d7d;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1562,6 +1562,11 @@ markdown-it-emoji@^2.0.2:
   resolved "https://registry.yarnpkg.com/markdown-it-emoji/-/markdown-it-emoji-2.0.2.tgz#cd42421c2fda1537d9cc12b9923f5c8aeb9029c8"
   integrity sha512-zLftSaNrKuYl0kR5zm4gxXjHaOI3FAOEaloKmRA5hijmJZvSjmxcokOLlzycb/HXlUFWzXqpIEoyEMCE4i9MvQ==
 
+markdown-it-footnote@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/markdown-it-footnote/-/markdown-it-footnote-4.0.0.tgz#02ede0cb68a42d7e7774c3abdc72d77aaa24c531"
+  integrity sha512-WYJ7urf+khJYl3DqofQpYfEYkZKbmXmwxQV8c8mO/hGIhgZ1wOe7R4HLFNwqx7TjILbnC98fuyeSsin19JdFcQ==
+
 markdown-it-inject-linenumbers@^0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/markdown-it-inject-linenumbers/-/markdown-it-inject-linenumbers-0.3.0.tgz#654364fa7a2dcb5f4461ef6d29d2603b74b29fd7"


### PR DESCRIPTION
Addresses the last task in #57 

Can you make sure I added the yarn module in the right way? I ran `yarn add markdown-it-footnote`

Are these styles good? I straight up added `20px` margin-top for the footnotes section. Dark mode needed a new color which is called something like `fg-dimmed` in a variable in Github's styling.

![image](https://github.com/jannis-baum/vivify/assets/15036238/87b15850-49cb-4f4f-acac-c9f80e71b148)

![image](https://github.com/jannis-baum/vivify/assets/15036238/e31f81fd-44a0-49b7-be19-4aabd8827d6d)
