### PR TITLE
(Followup #61) Fix definition lists with multiple consecutive <dd>

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -148,7 +148,6 @@ dt {
     font-weight: bold;
     box-sizing: border-box;
     padding: 0.25em;
-    border-right: 0.2px solid #444;
     margin: 0.25em 0;
 }
 dd {
@@ -156,10 +155,23 @@ dd {
     flex-grow: 1;
     text-align: left;
     box-sizing: border-box;
+    border-left: 0.2px solid #444;
     margin: 0;
     padding: 0.25em;
     margin: 0.25em 0;
 }
+dd + dd {
+    margin-left: 20%;
+    margin-top: -0.25em;
+}
+dt + dt {
+    margin-right: 80%;
+    margin-top: -0.25em;
+}
+dt + dt + dd {
+    margin-left: 20%;
+    margin-top: -2.25em; /* Align definition with last term */
+}                        /* Self height - margin - padding */
 
 /* --------------------------------------------------------------------------
  * LIGHT MODE --------------------------------------------------------------- */

--- a/static/style.css
+++ b/static/style.css
@@ -222,4 +222,8 @@ dt + dt + dd {
         border-top: 0.2px solid #d8dee4;
         color: #656d76;
     }
+
+    dd {
+        border-left: 0.2px solid #d8dee4;
+    }
 }


### PR DESCRIPTION
Followup #61

Hi, I noticed a few issues with definition lists' styling. I found a very helpful blog post about this here:

https://clicknathan.com/web-design/styling-html-5-description-lists-formerly-known-as-definition-lists-properly/

My fix is largely based on a comment on that post by Chad.

Also this link helped quite a bit:

https://pandoc.org/MANUAL.html#definition-lists

The markdown-it plugin uses that spec.

# Test document

```md
## Multiple consecutive \<dd>

dog
    : a domesticated canid
    : a clamp binding together two timbers
    : an utter failure; flop

cat
    : a small domesticated carnivore
    : a devotee of jazz
    : a movable shelter for providing protection when approaching a fortification

foobar
    : bazqux

## Paragraphs in \<dd>

term
    
:   This is the first paragraph.

    This is the second paragraph. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed congue egestas est at maximus. Ut blandit ligula nec iaculis dignissim. Duis ut diam nibh. Curabitur sed consectetur lacus. Integer fringilla metus quis justo condimentum iaculis. Vivamus arcu metus, luctus id posuere eget, rutrum eu neque. Donec a lectus mauris. Etiam magna eros, commodo ut lectus id, finibus sodales est. Suspendisse quis rhoncus purus.

    Hello from the third paragraph!

## Multiple consecutive \<dt>

<dl>
    <dt>Firefox</dt>
    <dt>Mozilla Firefox</dt>
    <dt>Fx</dt>
    <dd>A free, open source, cross-platform, graphical web browser
        developed by the Mozilla Corporation and hundreds of volunteers.</dd>
</dl>
```

# Before PR

![before-dark](https://github.com/jannis-baum/vivify/assets/15036238/25c5d64c-5696-4eb6-851e-f21b5b746b1c)

![before-light](https://github.com/jannis-baum/vivify/assets/15036238/dd4c7cfa-3ef4-4f78-943a-cdd04dd4d2b5)

# After PR

![after-dark](https://github.com/jannis-baum/vivify/assets/15036238/3e036946-a554-457f-ae81-fc1e2ebccdba)

![after-light](https://github.com/jannis-baum/vivify/assets/15036238/643c0bf6-939e-4776-b54c-4d8e64526ad0)