### PR TITLE
feat(#66): add default style for kbd tag

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -174,6 +174,17 @@ dt + dt + dd {
 }                        /* Self height - margin - padding */
 
 /* --------------------------------------------------------------------------
+ * KEYBOARD INPUT ----------------------------------------------------------- */
+
+kbd {
+    background-color: #161616;
+    border: 1px solid #242424;
+    box-shadow: inset 0 -1px 0 #242424;
+    padding: 3px 5px;
+    border-radius: 6px;
+}
+
+/* --------------------------------------------------------------------------
  * LIGHT MODE --------------------------------------------------------------- */
 @media (prefers-color-scheme: light) {
     html {
@@ -225,5 +236,11 @@ dt + dt + dd {
 
     dd {
         border-left: 0.2px solid #d8dee4;
+    }
+
+    kbd {
+        background-color: #f6f8fa;
+        border: 1px solid #eff1f3;
+        box-shadow: inset 0 -1px 0 #eff1f3;
     }
 }


### PR DESCRIPTION
Issue #66 

Markdown:
```md
## Inserting special characters in macros

When you need to insert special characters like `<Esc>` (displayed as `^[`) in a macro, press <kbd>Ctrl</kbd> + <kbd>v</kbd> in insert mode followed by <kbd>Esc</kbd>
```

![example1](https://github.com/jannis-baum/vivify/assets/15036238/876379e2-c9cf-4af5-a397-687659d49354)

![example2](https://github.com/jannis-baum/vivify/assets/15036238/e9d6d49e-f774-4517-9e52-d5432bd45645)

For dark theme, the border color `#242424` is a new one, in github's CSS it's a var named `--borderColor-neutral-muted`

Font-size may be slightly different, it looks like for a \<kbd> tag the font-size is already `0.75rem` without specifying it, and on github it's 5px smaller than normal text. I thought this looks good without specifying anything so I didn't.