### PR TITLE
Fix decoding VIV_PATH

### DIFF
--- a/src/routes/viewer.ts
+++ b/src/routes/viewer.ts
@@ -6,7 +6,7 @@ import { Request, Response, Router } from 'express';
 
 import { clientsAt, messageClients } from '../app.js';
 import config from '../config.js';
-import { absPath, pcomponents, pmime, preferredPath } from '../utils/path.js';
+import { pcomponents, pmime, preferredPath, urlToPath } from '../utils/path.js';
 import { renderDirectory, renderTextFile, shouldRender } from '../parser/parser.js';
 
 export const router = Router();
@@ -81,7 +81,7 @@ router.get(/.*/, async (req: Request, res: Response) => {
             </body>
             <script>
                 window.VIV_PORT = "${config.port}";
-                window.VIV_PATH = "${absPath(req.path)}";
+                window.VIV_PATH = "${urlToPath(req.path)}";
             </script>
             ${config.scripts ? `<script type="text/javascript">${config.scripts}</script>` : ''}
             <script type="text/javascript" src="/static/client.js"></script>

--- a/src/utils/path.ts
+++ b/src/utils/path.ts
@@ -21,10 +21,10 @@ export const pcomponents = (path: string) => {
     return components;
 };
 
-export const absPath = (path: string) => path.replace(/^\/~/, homedir()).replace(/\/+$/, '');
-
 export const urlToPath = (url: string) => {
-    const path = absPath(decodeURIComponent(url.replace(/^\/(viewer|health)/, '')));
+    const path = decodeURIComponent(url.replace(/^\/(viewer|health)/, ''))
+        .replace(/^\/~/, homedir())
+        .replace(/\/+$/, '');
     return path === '' ? '/' : path;
 };
 


### PR DESCRIPTION
Close #147

Just in case someone wonders what this is: The client-side `VIV_PATH` was set to the URI-encoded path, i.e. Vivify registered the client at the encoded path, i.e. the `POST /viewer` API was broken for URLs that aren't the same encoded and decoded. I realized this while implementing the "scroll on open" over on vivify.vim.