### PR TITLE
Disown monitor_server function.

### DIFF
--- a/viv
+++ b/viv
@@ -59,7 +59,8 @@ monitor_server() {
         sleep 0.3
     done
 }
-monitor_server &
+monitor_server </dev/null &>/dev/null &
+disown
 
 # print stdout of vivify-server until STARTUP COMPLETE is found
 tail -f "$output" | while read line; do


### PR DESCRIPTION
Change allows for controlling terminal to exit without interruption by viv functions.