### PR TITLE
Improve install robustness

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,6 +72,8 @@ $(SERVER_PATH_LINUX): $(BUNDLE_PATH) sea-config.json
 	rm -rf $(SERVER_PATH_LINUX)
 	node --experimental-sea-config sea-config.json
 	cp $(shell command -v node) $(SERVER_PATH_LINUX)
+	objdump -p $(SERVER_PATH_LINUX) | grep 'NEEDED' | grep -q 'libdl.so.2' || \
+		{ echo "Your $(shell command -v node) does not support Node SEA. Please install Node through nvm and try again."; exit 1; }
 	chmod +w $(SERVER_PATH_LINUX)
 	node_modules/.bin/postject $(SERVER_PATH_LINUX) NODE_SEA_BLOB $(BUILD_DIR)/sea-prep.blob \
 			  --sentinel-fuse NODE_SEA_FUSE_fce680ab2cc467b6e072b8b5df1996b2

--- a/Makefile
+++ b/Makefile
@@ -72,8 +72,12 @@ $(SERVER_PATH_LINUX): $(BUNDLE_PATH) sea-config.json
 	rm -rf $(SERVER_PATH_LINUX)
 	node --experimental-sea-config sea-config.json
 	cp $(shell command -v node) $(SERVER_PATH_LINUX)
-	objdump -p $(SERVER_PATH_LINUX) | grep 'NEEDED' | grep -q 'libdl.so.2' || \
-		{ echo "Your $(shell command -v node) does not support Node SEA. Please install Node through nvm and try again."; exit 1; }
+	@ objdump -p $(SERVER_PATH_LINUX) | grep 'NEEDED' | grep -q 'libdl.so.2' || \
+		{ \
+		printf "\n\n\x1b[1;31mYour $(shell command -v node) does not support Node SEA, which is needed to compile Vivify.\x1b[0m\n"; \
+		printf "\x1b[1;31mPlease install Node.js through Node Version Manager (nvm) and try again.\x1b[0m\n"; \
+		exit 1; \
+		}
 	chmod +w $(SERVER_PATH_LINUX)
 	node_modules/.bin/postject $(SERVER_PATH_LINUX) NODE_SEA_BLOB $(BUILD_DIR)/sea-prep.blob \
 			  --sentinel-fuse NODE_SEA_FUSE_fce680ab2cc467b6e072b8b5df1996b2

--- a/viv
+++ b/viv
@@ -40,7 +40,7 @@ cleanup() {
 }
 trap cleanup EXIT
 
-nohup vivify-server $@ > "$output" 2> /dev/null &
+nohup vivify-server "$@" > "$output" 2> /dev/null &
 server_pid=$!
 
 monitor_server() {

--- a/viv
+++ b/viv
@@ -63,7 +63,7 @@ monitor_server() {
 monitor_server &
 
 # print stdout of vivify-server until STARTUP COMPLETE is found
-tail -f "$output" | while read line; do
+tail -f "$output" | while read -r line; do
     # server finished starting
     if echo "$line" | grep --quiet "STARTUP COMPLETE"; then
         pkill -P $$ tail

--- a/viv
+++ b/viv
@@ -18,7 +18,7 @@ EOF
 
 print_bug_report() {
     cat <<EOF
-Fatal: "`command -v vivify-server`" crashed.
+Fatal: "$(command -v vivify-server)" crashed.
 Please use the link below to submit a bug report.
 
 The bug report template will help you provide the necessary information and
@@ -34,7 +34,7 @@ if [ "$#" -lt 1 -o "$1" = "-h" -o "$1" = "--help" ]; then
     exit 1
 fi
 
-output=`mktemp`
+output=$(mktemp)
 cleanup() {
     rm -f "$output"
 }

--- a/viv
+++ b/viv
@@ -1,5 +1,8 @@
 #!/bin/sh
 
+install_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd -P)
+vivify_server="$install_dir/vivify-server"
+
 print_usage() {
     cat <<EOF
 usage: viv target [target ...]
@@ -18,7 +21,7 @@ EOF
 
 print_bug_report() {
     cat <<EOF
-Fatal: "$(command -v vivify-server)" crashed.
+Fatal: "$vivify_server" crashed.
 Please use the link below to submit a bug report.
 
 The bug report template will help you provide the necessary information and
@@ -29,8 +32,28 @@ https://github.com/jannis-baum/Vivify/issues/new?labels=type%3Abug&template=bug-
 EOF
 }
 
+print_server_file_error() {
+    cat <<EOF
+Fatal: "$vivify_server" $1.
+
+Please make sure that the "vivify-server" binary is located in the same
+directory as the "viv" script and that it is executable.
+
+EOF
+}
+
 if [ "$#" -lt 1 -o "$1" = "-h" -o "$1" = "--help" ]; then
     print_usage
+    exit 1
+fi
+
+if ! test -f "$vivify_server"; then
+    print_server_file_error "not found"
+    exit 1
+fi
+
+if ! test -x "$vivify_server"; then
+    print_server_file_error "not executable"
     exit 1
 fi
 
@@ -40,7 +63,7 @@ cleanup() {
 }
 trap cleanup EXIT
 
-nohup vivify-server "$@" > "$output" 2> /dev/null &
+nohup "$vivify_server" "$@" > "$output" 2> /dev/null &
 server_pid=$!
 
 monitor_server() {


### PR DESCRIPTION
Close #175

- `viv` now uses `vivify-server` from directory its in to prevent confusion from multiple installs
- i used https://www.shellcheck.net on the script and realized there was a bug that didn't let us open targets with spaces, this is now fixed
- i dropped support of super old non-POSIX compatible shells that don't understand the `$()` syntax so that the script is more readable