### PR TITLE
Custom alert markers (for Obsidian Callout style alert)

### DIFF
--- a/src/parser/markdown.ts
+++ b/src/parser/markdown.ts
@@ -65,8 +65,10 @@ mdit.use(anchor, {
         placement: 'before',
     }),
 });
+mdit.use(githubAlerts, {
+    markers: '*',
+});
 mdit.use(graphviz);
-mdit.use(githubAlerts);
 mdit.use(mermaid);
 
 const renderMarkdown: Renderer = (content: string) => {

--- a/static/colors.css
+++ b/static/colors.css
@@ -44,6 +44,8 @@
     --alert-warning: #ffaf00;
     --alert-caution: #ff5f5f;
 
+    --alert-custom-default: #c0c0c0;
+
     --ipynb-bg-error: rgba(255, 0, 0, 0.1);
 }
 
@@ -96,6 +98,8 @@
         --alert-important: #8250df;
         --alert-warning: #bf8700;
         --alert-caution: #cf222e;
+
+        --alert-custom-default: #404040;
 
         --ipynb-bg-error: rgba(255, 0, 0, 0.1);
     }

--- a/static/colors.css
+++ b/static/colors.css
@@ -44,8 +44,6 @@
     --alert-warning: #ffaf00;
     --alert-caution: #ff5f5f;
 
-    --alert-custom-default: #c0c0c0;
-
     --ipynb-bg-error: rgba(255, 0, 0, 0.1);
 }
 
@@ -98,8 +96,6 @@
         --alert-important: #8250df;
         --alert-warning: #bf8700;
         --alert-caution: #cf222e;
-
-        --alert-custom-default: #404040;
 
         --ipynb-bg-error: rgba(255, 0, 0, 0.1);
     }

--- a/static/markdown.css
+++ b/static/markdown.css
@@ -149,6 +149,14 @@ blockquote {
     vertical-align: text-bottom;
     fill: currentColor;
 }
+/* default style for custom markers (Obsidian Callout style) */
+.markdown-alert {
+    border-left: .25rem solid var(--alert-custom-default);
+}
+.markdown-alert .markdown-alert-title {
+    color: var(--alert-custom-default);
+}
+/* default styles for GitHub style markers */
 .markdown-alert-note {
     border-left: .25rem solid var(--alert-note);
 }

--- a/static/markdown.css
+++ b/static/markdown.css
@@ -149,12 +149,12 @@ blockquote {
     vertical-align: text-bottom;
     fill: currentColor;
 }
-/* default style for custom markers (Obsidian Callout style) */
+/* default style for unconfigured custom markers (Obsidian Callout style) */
 .markdown-alert {
-    border-left: .25rem solid var(--alert-custom-default);
+    border-left: .25rem solid var(--alert-note);
 }
 .markdown-alert .markdown-alert-title {
-    color: var(--alert-custom-default);
+    color: var(--alert-note);
 }
 /* default styles for GitHub style markers */
 .markdown-alert-note {

--- a/tests/rendering/markdown-additional.md
+++ b/tests/rendering/markdown-additional.md
@@ -67,13 +67,15 @@ This paragraph has a red background color.{style=background-color:red}
 
 ### With a custom title
 
-> [!NOTE] Foo bar
-> 'Note' with a custom title
+> [!TIP] Foo bar
+> 'Tip' with a custom title
 
 ### Using custom markers ([Obsidian Callout](https://help.obsidian.md/Editing+and+formatting/Callouts) style)
 
 > [!CUSTOM]
-> Something more special
+> Set custom icon and color for any marker
+>
+> If unconfigured, it's styled like 'Note'
 
 > [!fOoBaR]
 > The marker is case-insensitive and turns into Title Case

--- a/tests/rendering/markdown-additional.md
+++ b/tests/rendering/markdown-additional.md
@@ -42,11 +42,13 @@ While not a markdown syntax, this has a default style:
 
 Press <kbd>Ctrl</kbd> + <kbd>C</kbd> to copy, and <kbd>Ctrl</kbd> + <kbd>V</kbd> to paste!
 
-## Custom attributes
+## Custom attribute
 
 This paragraph has a red background color.{style=background-color:red}
 
-## Github alert blockquote
+## GitHub style alert
+
+### The 5 default GitHub style alerts
 
 > [!NOTE]  
 > Something to take into account
@@ -63,7 +65,18 @@ This paragraph has a red background color.{style=background-color:red}
 > [!CAUTION]
 > Do not do this and that!
 
-With a custom title:
+### With a custom title
 
 > [!NOTE] Foo bar
-> Hello
+> 'Note' with a custom title
+
+### Using custom markers ([Obsidian Callout](https://help.obsidian.md/Editing+and+formatting/Callouts) style)
+
+> [!CUSTOM]
+> Something more special
+
+> [!fOoBaR]
+> The marker is case-insensitive and turns into Title Case
+
+> [!CUSTOM] paY aTtEntiOn
+> You can use a custom title with a custom marker as well


### PR DESCRIPTION
Issue: #141 

- [x] Enable `markers: '*'`
- [ ] Make svg icon configurable
  - the [plugin](https://github.com/antfu/markdown-it-github-alerts/) allows setting the icons in the initialization like
    ```js
    mdit.use(githubAlerts, {
      ...
      icons: {
        custom1: svgTag1,
        custom2: svgTag2,
        ...
      } 
      ...
    });
    ```
  - Make a new option for vivify's `config.json`, where you can set either octicon by name or svg by path
  - Allow overriding the default GH icons in the same option
- [ ] Color configuration
  - To be decided... Setting it via custom stylesheets always works but is it too annoying to configure a marker in 2 separate places?

Limitation of [plugin](https://github.com/antfu/markdown-it-github-alerts/):

Using a custom marker with spaces doesn't work, such as:

```md
> [!Pay Attention]
> Hey
```

@Tweekism tested that on Obsidian this does work (thanks!), and I think it makes a lot of sense so I'd wish it worked here too.

This however works of course:

```md
> [!custom] Pay Attention
> Hey
```

Feels like more work though.

Consider sending PR to the plugin if it's easy to add.