### PR TITLE
test: fix badly formatted toc link

### DIFF
--- a/tests/rendering/markdown-additional.md
+++ b/tests/rendering/markdown-additional.md
@@ -36,7 +36,7 @@ C -->|One| D[Result 1]
 C -->|Two| E[Result 2]
 ```
 
-## \<kbd> tag
+## kbd tag
 
 While not a markdown syntax, this has a default style:
 


### PR DESCRIPTION
The fact that the HTML tag is escaped in the header doesn't carry over to the table of contents link

Before:

![before](https://github.com/user-attachments/assets/317a5a5c-6289-4ffe-9112-bc0d63075167)

After:

![after](https://github.com/user-attachments/assets/417ff786-b482-46ed-b6a5-3d41d657950a)
