### PR TITLE
feat(#177): enable understanding of front matter

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "markdown-it-deflist": "^3.0.0",
     "markdown-it-emoji": "^3.0.0",
     "markdown-it-footnote": "^4.0.0",
+    "markdown-it-front-matter": "^0.2.4",
     "markdown-it-github-alerts": "^0.3.0",
     "markdown-it-inject-linenumbers": "^0.3.0",
     "markdown-it-mark": "^4.0.0",

--- a/src/parser/markdown.ts
+++ b/src/parser/markdown.ts
@@ -1,5 +1,6 @@
 import MarkdownIt from 'markdown-it';
 import anchor from 'markdown-it-anchor';
+import frontMatter from 'markdown-it-front-matter';
 import highlight from './highlight.js';
 import graphviz from './dot.js';
 import mermaid from './mermaid.js';
@@ -59,6 +60,9 @@ mdit.use(toc, config.tocOptions);
 
 // MARK: untyped plugins done
 
+// markdown-it-front-matter requires a callback function but we aren’t doing
+// anything with it, so we just pass in a noop.
+mdit.use(frontMatter, () => {});
 // anchor has to be added after attribute plugin for ids to work
 mdit.use(anchor, {
     permalink: anchor.permalink.ariaHidden({

--- a/tests/rendering/markdown-additional.md
+++ b/tests/rendering/markdown-additional.md
@@ -1,3 +1,7 @@
+---
+front-matter: This should not be shown in the renderer
+---
+
 # Additional Markdown test file
 
 Test various other Markdown syntax here, starting with the table of contents

--- a/yarn.lock
+++ b/yarn.lock
@@ -2190,6 +2190,11 @@ markdown-it-footnote@^4.0.0:
   resolved "https://registry.yarnpkg.com/markdown-it-footnote/-/markdown-it-footnote-4.0.0.tgz#02ede0cb68a42d7e7774c3abdc72d77aaa24c531"
   integrity sha512-WYJ7urf+khJYl3DqofQpYfEYkZKbmXmwxQV8c8mO/hGIhgZ1wOe7R4HLFNwqx7TjILbnC98fuyeSsin19JdFcQ==
 
+markdown-it-front-matter@^0.2.4:
+  version "0.2.4"
+  resolved "https://registry.yarnpkg.com/markdown-it-front-matter/-/markdown-it-front-matter-0.2.4.tgz#cf29bc8222149b53575699357b1ece697bf39507"
+  integrity sha512-25GUs0yjS2hLl8zAemVndeEzThB1p42yxuDEKbd4JlL3jiz+jsm6e56Ya8B0VREOkNxLYB4TTwaoPJ3ElMmW+w==
+
 markdown-it-github-alerts@^0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/markdown-it-github-alerts/-/markdown-it-github-alerts-0.3.0.tgz#acab7db57f4e204c8d1c987403c367738d7026b0"


### PR DESCRIPTION
Hi @jannis-baum, I hope you don’t mind me posting a PR out of the blue. I was looking for front matter support in Vivify and found #177. I looked into it a little bit myself and realised that we could get the basic functionality implemented by installing and enabling `markdown-it-front-matter`, so I thought I would just go for it! ☺️

## Why

Some users add metadata to their Markdown files in the form of YAML-style front matter and it currently gets treated as regular content, which looks a bit odd when rendered on the page.

Instead, we would like to be able to identify front matter and not render it to the page. Ideally we would like to make the metadata available and/or optionally render it to the page in some way, but this would require some reworking of the current setup.

## What

* Install `markdown-it-front-matter`[^1], which enables `markdown-it` to parse YAML-style front matter.
* Enable `markdown-it-front-matter` via `MarkdownIt.use()` like we do with other plugins.
  * **Note:** This doesn’t actually do anything other than enable `markdown-it` to recognise front matter and not treat it as regular content.

[^1]: https://github.com/ParkSB/markdown-it-front-matter

## Screenshots/recordings

### Source

<img width="819" alt="Markdown file with the following text: --- id: 202411110946, title:, Vivify front matter demo, date: 2024-11-11 09:46, tags: [vivify, markdown, parsing, yaml, front-matter] --- # Vivify front matter demo. Hello there! This is a demo document for showing front matter functionality in Vivify." src="https://github.com/user-attachments/assets/73a0edd6-c0d3-4c21-9ab6-8bce6e56c62a">

### Output, before

<img width="958" alt="Document showing a long string of text at the top: “id: 202411110946 title: Vivify front matter demo date: 2024-11-11 09:46 tags: [vivify, markdown, parsing, yaml, front-matter]”. The long string is followed by a heading: “Vivify front matter demo”, which is followed by a paragraph: “Hello there! This is a demo document for showing front matter functionality in Vivify.”" src="https://github.com/user-attachments/assets/6184a75f-6cf2-4556-a0ed-b0e997e63565">

### Output, after

<img width="957" alt="Document showing a heading: “Vivify front matter demo”, which is followed by a paragraph: “Hello there! This is a demo document for showing front matter functionality in Vivify.”" src="https://github.com/user-attachments/assets/8bd5ebf0-58d7-4e04-a5b9-e1ce5cc5f219">

## Related PRs/issues

https://github.com/jannis-baum/Vivify/issues/177