### PR TITLE
macOS 15.1.1 fixes

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -64,6 +64,13 @@ jobs:
     needs: [test]
     runs-on: macos-latest
     steps:
+      - name: get Homebrew Node
+        # lists node dependencies, these need to be mirrored for the Homebrew package
+        run: |
+          brew update
+          brew install node
+          brew deps --tree --installed node 
+          echo $PATH
       - name: checkout
         uses: actions/checkout@v4
       - name: build

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -64,24 +64,28 @@ jobs:
     needs: [test]
     runs-on: macos-latest
     steps:
+      - name: checkout
+        uses: actions/checkout@v4
       - name: get Homebrew Node
         # lists node dependencies, these need to be mirrored for the Homebrew package
         run: |
           brew update
           brew install node
-          brew deps --tree --installed node 
-          echo $PATH
-      - name: checkout
-        uses: actions/checkout@v4
+          brew deps --installed --direct node > macos-deps.txt
       - name: build
         run: |
           yarn
           VIV_VERSION="${{ github.ref_name }}" make macos
-      - name: upload artifact
+      - name: upload artifact (macOS build)
         uses: actions/upload-artifact@v4
         with:
           name: vivify-macos
           path: build/macos
+      - name: upload artifact (macOS dependency list)
+        uses: actions/upload-artifact@v4
+        with:
+          name: macos-deps
+          path: macos-deps.txt
 
   release:
     name: Release
@@ -110,6 +114,12 @@ jobs:
           chmod +x ./vivify-linux/* ./vivify-macos/*
           tar -czf vivify-linux.tar.gz vivify-linux
           tar -czf vivify-macos.tar.gz vivify-macos
+      # macos dependencies -----------------------------------------------------
+      - name: download macos dependencies
+        uses: actions/download-artifact@v4
+        with:
+          name: macos-deps
+          path: macos-deps
       # release notes ----------------------------------------------------------
       # actions/checkout seems to have a bug where annotated tags are converted
       # to simple tags so we have to fetch them explicitly again
@@ -128,6 +138,12 @@ jobs:
           echo -e "Linux: \`$(sha256sum vivify-linux.tar.gz | cut -d' ' -f1)\`\\" \
               >> release.md
           echo -e "macOS: \`$(sha256sum vivify-macos.tar.gz | cut -d' ' -f1)\`" \
+              >> release.md
+          echo -e '\n**macOS Homebrew dependencies**\n\n```plain' \
+              >> release.md
+          cat macos-deps/macos-deps.txt \
+              >> release.md
+          echo -e '```' \
               >> release.md
       - name: print release notes for logs
         run: cat release.md


### PR DESCRIPTION
Close #191

- use Homebrew Node for macOS build and list Homebrew dependencies to make sure libraries & dependencies are always correct for the Homebrew package