### PR TITLE
Set Notebook ANSI colors

### DIFF
--- a/src/parser/ipynb.ts
+++ b/src/parser/ipynb.ts
@@ -16,6 +16,7 @@ import { Renderer } from './parser.js';
 import { AnsiUp } from 'ansi_up';
 
 const ansiup = new AnsiUp();
+ansiup.use_classes = true;
 const renderAnsi: Renderer = (content: string) => ansiup.ansi_to_html(content);
 
 function joinMultilineString(str: MultilineString): string {

--- a/static/colors.css
+++ b/static/colors.css
@@ -1,5 +1,6 @@
 /* --------------------------------------------------------------------------
  * DARK MODE ---------------------------------------------------------------- */
+/* from https://github.com/jannis-baum/dotfiles/blob/main/lib/color-schemes/jellyfish.yaml */
 
 :root {
     --bg-primary: black;
@@ -47,10 +48,27 @@
     --alert-caution: #ff5f5f;
 
     --ipynb-bg-error: rgba(255, 0, 0, 0.1);
+    --ipynb-ansi-black: #616161;
+    --ipynb-ansi-brblack: #8e8e8e;
+    --ipynb-ansi-red: #ff8272;
+    --ipynb-ansi-brred: #ffc4bd;
+    --ipynb-ansi-green: #b4fa72;
+    --ipynb-ansi-brgreen: #d6fcb9;
+    --ipynb-ansi-yellow: #fefdc2;
+    --ipynb-ansi-bryellow: #fefdd5;
+    --ipynb-ansi-blue: #a5d5fe;
+    --ipynb-ansi-brblue: #c1e3fe;
+    --ipynb-ansi-magenta: #ff8ffd;
+    --ipynb-ansi-brmagenta: #ffb1fe;
+    --ipynb-ansi-cyan: #d0d1fe;
+    --ipynb-ansi-brcyan: #e5e6fe;
+    --ipynb-ansi-white: #f1f1f1;
+    --ipynb-ansi-brwhite: #fefefe;
 }
 
 /* --------------------------------------------------------------------------
  * LIGHT MODE --------------------------------------------------------------- */
+/* adapted from GitHub's light theme */
 
 @media (prefers-color-scheme: light) {
     :root {
@@ -102,5 +120,21 @@
         --alert-caution: #cf222e;
 
         --ipynb-bg-error: rgba(255, 0, 0, 0.1);
+        --ipynb-ansi-black: #3e424d;
+        --ipynb-ansi-brblack: #282c36;
+        --ipynb-ansi-red: #e75c58;
+        --ipynb-ansi-brred: #b22b31;
+        --ipynb-ansi-green: #00a250;
+        --ipynb-ansi-brgreen: #007427;
+        --ipynb-ansi-yellow: #ddb62b;
+        --ipynb-ansi-bryellow: #b27d12;
+        --ipynb-ansi-blue: #208ffb;
+        --ipynb-ansi-brblue: #0065ca;
+        --ipynb-ansi-magenta: #d160c4;
+        --ipynb-ansi-brmagenta: #a03196;
+        --ipynb-ansi-cyan: #60c6c8;
+        --ipynb-ansi-brcyan: #258f8f;
+        --ipynb-ansi-white: #c5c1b4;
+        --ipynb-ansi-brwhite: #a1a6b2;
     }
 }

--- a/static/ipynb.css
+++ b/static/ipynb.css
@@ -27,3 +27,46 @@
     padding: unset;
     background-color: unset;
 }
+
+/* --------------------------------------------------------------------------
+ * ANSI COLORS -------------------------------------------------------------- */
+
+.ansi-black-fg { color: var(--ipynb-ansi-black); }
+.ansi-black-bg { background-color: var(--ipynb-ansi-black); }
+.ansi-bright-black-fg { color: var(--ipynb-ansi-brblack); }
+.ansi-bright-black-bg { background-color: var(--ipynb-ansi-brblack); }
+
+.ansi-red-fg { color: var(--ipynb-ansi-red); }
+.ansi-red-bg { background-color: var(--ipynb-ansi-red); }
+.ansi-bright-red-fg { color: var(--ipynb-ansi-brred); }
+.ansi-bright-red-bg { background-color: var(--ipynb-ansi-brred); }
+
+.ansi-green-fg { color: var(--ipynb-ansi-green); }
+.ansi-green-bg { background-color: var(--ipynb-ansi-green); }
+.ansi-bright-green-fg { color: var(--ipynb-ansi-brgreen); }
+.ansi-bright-green-bg { background-color: var(--ipynb-ansi-brgreen); }
+
+.ansi-yellow-fg { color: var(--ipynb-ansi-yellow); }
+.ansi-yellow-bg { background-color: var(--ipynb-ansi-yellow); }
+.ansi-bright-yellow-fg { color: var(--ipynb-ansi-bryellow); }
+.ansi-bright-yellow-bg { background-color: var(--ipynb-ansi-bryellow); }
+
+.ansi-blue-fg { color: var(--ipynb-ansi-blue); }
+.ansi-blue-bg { background-color: var(--ipynb-ansi-blue); }
+.ansi-bright-blue-fg { color: var(--ipynb-ansi-brblue); }
+.ansi-bright-blue-bg { background-color: var(--ipynb-ansi-brblue); }
+
+.ansi-magenta-fg { color: var(--ipynb-ansi-magenta); }
+.ansi-magenta-bg { background-color: var(--ipynb-ansi-magenta); }
+.ansi-bright-magenta-fg { color: var(--ipynb-ansi-brmagenta); }
+.ansi-bright-magenta-bg { background-color: var(--ipynb-ansi-brmagenta); }
+
+.ansi-cyan-fg { color: var(--ipynb-ansi-cyan); }
+.ansi-cyan-bg { background-color: var(--ipynb-ansi-cyan); }
+.ansi-bright-cyan-fg { color: var(--ipynb-ansi-brcyan); }
+.ansi-bright-cyan-bg { background-color: var(--ipynb-ansi-brcyan); }
+
+.ansi-white-fg { color: var(--ipynb-ansi-white); }
+.ansi-white-bg { background-color: var(--ipynb-ansi-white); }
+.ansi-bright-white-fg { color: var(--ipynb-ansi-brwhite); }
+.ansi-bright-white-bg { background-color: var(--ipynb-ansi-brwhite); }

--- a/tests/rendering/notebook.ipynb
+++ b/tests/rendering/notebook.ipynb
@@ -36,17 +36,26 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "We can test stream outputs & ANSI by printing some text with \u001b[31mred\u001b[0m parts\n"
+      "   black  \u001b[30mfg_normal\u001b[0m  \u001b[40mbg_normal\u001b[0m  \u001b[90mfg_bright\u001b[0m  \u001b[100mbg_bright\u001b[0m\n",
+      "     red  \u001b[31mfg_normal\u001b[0m  \u001b[41mbg_normal\u001b[0m  \u001b[91mfg_bright\u001b[0m  \u001b[101mbg_bright\u001b[0m\n",
+      "   green  \u001b[32mfg_normal\u001b[0m  \u001b[42mbg_normal\u001b[0m  \u001b[92mfg_bright\u001b[0m  \u001b[102mbg_bright\u001b[0m\n",
+      "  yellow  \u001b[33mfg_normal\u001b[0m  \u001b[43mbg_normal\u001b[0m  \u001b[93mfg_bright\u001b[0m  \u001b[103mbg_bright\u001b[0m\n",
+      "    blue  \u001b[34mfg_normal\u001b[0m  \u001b[44mbg_normal\u001b[0m  \u001b[94mfg_bright\u001b[0m  \u001b[104mbg_bright\u001b[0m\n",
+      " magenta  \u001b[35mfg_normal\u001b[0m  \u001b[45mbg_normal\u001b[0m  \u001b[95mfg_bright\u001b[0m  \u001b[105mbg_bright\u001b[0m\n",
+      "    cyan  \u001b[36mfg_normal\u001b[0m  \u001b[46mbg_normal\u001b[0m  \u001b[96mfg_bright\u001b[0m  \u001b[106mbg_bright\u001b[0m\n",
+      "   white  \u001b[37mfg_normal\u001b[0m  \u001b[47mbg_normal\u001b[0m  \u001b[97mfg_bright\u001b[0m  \u001b[107mbg_bright\u001b[0m\n"
      ]
     }
    ],
    "source": [
-    "print('We can test stream outputs & ANSI by printing some text with \\033[31mred\\033[0m parts')"
+    "colors = ['black', 'red', 'green', 'yellow', 'blue', 'magenta', 'cyan', 'white']\n",
+    "for (i, c) in enumerate(colors):\n",
+    "    print(f'{c: >8}  \\033[3{i}mfg_normal\\033[0m  \\033[4{i}mbg_normal\\033[0m  \\033[9{i}mfg_bright\\033[0m  \\033[10{i}mbg_bright\\033[0m')"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 2,
    "id": "1ddd66b4-e45f-466b-a713-dc5eb1bc50c1",
    "metadata": {},
    "outputs": [
@@ -72,7 +81,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 3,
    "id": "a5598349-aafa-4527-bba5-e6de001e3121",
    "metadata": {},
    "outputs": [
@@ -83,9 +92,9 @@
      "traceback": [
       "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
       "\u001b[0;31mException\u001b[0m                                 Traceback (most recent call last)",
-      "Cell \u001b[0;32mIn[2], line 7\u001b[0m\n\u001b[1;32m      4\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m \u001b[38;5;21msome_other_fun\u001b[39m():\n\u001b[1;32m      5\u001b[0m     some_fun()\n\u001b[0;32m----> 7\u001b[0m \u001b[43msome_other_fun\u001b[49m\u001b[43m(\u001b[49m\u001b[43m)\u001b[49m\n",
-      "Cell \u001b[0;32mIn[2], line 5\u001b[0m, in \u001b[0;36msome_other_fun\u001b[0;34m()\u001b[0m\n\u001b[1;32m      4\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m \u001b[38;5;21msome_other_fun\u001b[39m():\n\u001b[0;32m----> 5\u001b[0m     \u001b[43msome_fun\u001b[49m\u001b[43m(\u001b[49m\u001b[43m)\u001b[49m\n",
-      "Cell \u001b[0;32mIn[2], line 2\u001b[0m, in \u001b[0;36msome_fun\u001b[0;34m()\u001b[0m\n\u001b[1;32m      1\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m \u001b[38;5;21msome_fun\u001b[39m():\n\u001b[0;32m----> 2\u001b[0m     \u001b[38;5;28;01mraise\u001b[39;00m \u001b[38;5;167;01mException\u001b[39;00m(\u001b[38;5;124m'\u001b[39m\u001b[38;5;124mHehe\u001b[39m\u001b[38;5;124m'\u001b[39m)\n",
+      "Cell \u001b[0;32mIn[3], line 7\u001b[0m\n\u001b[1;32m      4\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m \u001b[38;5;21msome_other_fun\u001b[39m():\n\u001b[1;32m      5\u001b[0m     some_fun()\n\u001b[0;32m----> 7\u001b[0m \u001b[43msome_other_fun\u001b[49m\u001b[43m(\u001b[49m\u001b[43m)\u001b[49m\n",
+      "Cell \u001b[0;32mIn[3], line 5\u001b[0m, in \u001b[0;36msome_other_fun\u001b[0;34m()\u001b[0m\n\u001b[1;32m      4\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m \u001b[38;5;21msome_other_fun\u001b[39m():\n\u001b[0;32m----> 5\u001b[0m     \u001b[43msome_fun\u001b[49m\u001b[43m(\u001b[49m\u001b[43m)\u001b[49m\n",
+      "Cell \u001b[0;32mIn[3], line 2\u001b[0m, in \u001b[0;36msome_fun\u001b[0;34m()\u001b[0m\n\u001b[1;32m      1\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m \u001b[38;5;21msome_fun\u001b[39m():\n\u001b[0;32m----> 2\u001b[0m     \u001b[38;5;28;01mraise\u001b[39;00m \u001b[38;5;167;01mException\u001b[39;00m(\u001b[38;5;124m'\u001b[39m\u001b[38;5;124mHehe\u001b[39m\u001b[38;5;124m'\u001b[39m)\n",
       "\u001b[0;31mException\u001b[0m: Hehe"
      ]
     }
@@ -110,7 +119,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 4,
    "id": "35411609-29dd-41fd-875b-c00bb8dbf99b",
    "metadata": {},
    "outputs": [
@@ -166,7 +175,7 @@
        "2  3  30"
       ]
      },
-     "execution_count": 3,
+     "execution_count": 4,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -179,7 +188,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 5,
    "id": "f7914d4f-2f2b-4a56-99d3-2b1252380b6a",
    "metadata": {},
    "outputs": [
@@ -189,15 +198,15 @@
        "<Axes: >"
       ]
      },
-     "execution_count": 7,
+     "execution_count": 5,
      "metadata": {},
      "output_type": "execute_result"
     },
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAMoAAAB4CAYAAACzZ23WAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjkuMSwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/TGe4hAAAACXBIWXMAAA9hAAAPYQGoP6dpAAAQz0lEQVR4nO2de2yU5Z7HP3NvCzMdCvYmrYByKtgAZ5FCRT2sW8ETYZfLH8Y/VjREjGlRrP/AZgPBP7YxhpSIVXOIojEhGCOFI7vLykFpw1kqKyxnrUgPcNCitS0gvdDLdC7v/vHMdGbobToX35n290ma9H3eZ573N5Pf931uv+d5DJqmaQiCMCpGvQ0QhFRAhCIIESBCEYQIEKEIQgSIUAQhAkQoghABIhRBiACz3gbcic/no6WlBbvdjsFg0NscYQKjaRrd3d3k5+djNI5eZySdUFpaWigoKNDbDGESce3aNWbOnDlqnqQTit1uB5TxDodDZ2uEiUxXVxcFBQWDPjcaSSeUQHPL4XCIUITY6WqBy3+C3/4zjNCUj6SJn3RCEYSYuX0dvjsCjYfgh/8GNMj/O8gtjrpIEYowMei7Bd8dhcZP4Wo9aN7gvYJlMNATU/EiFCF1cXVD038qcVw+AT538F7+b6F4A8xfC87YB4dEKJMcr9eL2+0eO2Oy4O6H70/Bpc/hhz+D16XSM3Ihay7MLYP7HodphVgsFkwmU1weK0KZpGiaRmtrKx0dHXqbMjaaBp5+cPeCuw80C+Q9qf6MFrBmgCUDTBaVv8MLHVcBcDqd5ObmxjwnJ0KZpAREkp2dTUZGRvJN7mqa6le4OqH/tj8xQ/0ZLZDmAKsDLGnDjmZpmkZvby/t7e0A5OXlxWSOCGUS4vV6B0Uyffp0vc0JEhBH3y3o7wCfR6WbAaMV0p2QPk3VHhEIOz09HYD29nays7NjaoaJUCYhgT5JRkaGzpagxOHuVeLo6wjvkBvNkOZUArFOjUgcdxL4jm63W4QiRIduzS1NU32Nfr84vAMhRpkgLVPVHLapYIgtbjde31GEIvx6uPv9Ncet4GgVKDHY/OJIs8csjkQgQhESi8cVbFZ5+kJuGFSHPH0a2BxgjM8wbqIQoQjxxzOgOuN9t1T/YxAD2Oz+miMz6cURighFiA9ed1Acd4aLWO2qQ57mBFNqulzyNQaF1MHrgZ4bcOMStDVC549BkVinQOZMyCmGGffBlBlxE8mxY8d4+OGHcTqdTJ8+ndWrV3PlypW4lD0SqSlvIe5omkaf2zt2Rp8X+rtUn2OgGwjZaNSSoWqNNCeY/bPkXpSgRiHdYhrX6FRPTw+VlZUsWLCA27dvs2PHDtatW8f58+fHXKkYLSIUAYA+t5f5O/5Ll2dfeG0VGdbIXXHDhg1h1++//z533XUXFy5coLg4+lD60ZCml5ByXLp0iaeffpo5c+bgcDiYNWsWAM3NzQl7ptQoAqCaPxd2PQ6uHtWscnWGr+kwWYOz5Obh46tiefZ4WLNmDffccw/79u0jPz8fn89HcXExAwMDY384SkQokx1Ng4HbGPpukdHXERSHGTDaxh1flWhu3rxJU1MT+/bt45FHHgHg1KlTCX+uCGUyomlqIrC7FTq6g8GHEBJfNU2NXCWBOEKZNm0a06dP5w9/+AN5eXk0Nzezbdu2hD9XhDJZ0DT4+S9qNeDfvoKFr0KfD8wGFV8VmOew2ZNOHKEYjUYOHjzISy+9RHFxMUVFRbz55pusWLEioc8dl1Cqqqo4dOgQFy9eJD09nYceeojXX3+doqKiwTz9/f28+uqrHDx4EJfLxapVq3j77bfJycmJu/FCBLR/p8TReAh+8c81TC0IxldlzvCLI3XGdcrKyrhw4UJYWqLPwxrXr1NXV0d5eTkNDQ0cP34ct9vNypUr6ekJzsS+8sorfPbZZ3zyySfU1dXR0tLC+vXr4264MAo3r0D9G/B2Kby9TP3/yxXVCZ//T/DE6+C4GzLvVqEkKSQSvRhXjXLs2LGw6w8++IDs7GzOnj3Lo48+SmdnJ++99x4HDhzgscceA2D//v3MmzePhoYGli1bFj/LhXA6rsG3tar2+Pl8MN1ogfvK1EYLRU+o2qO/H65e1c3UVCSmPkpnZycAWVlZAJw9exa3201ZWdlgnvvvv5/CwkJOnz49rFBcLhcuVzDkuqurKxaTJhfdbXDhsBLHta+C6QYTzPmdEsf9T6qOuRATUQvF5/OxdetWli9fPjgb2traitVqxel0huXNycmhtbV12HKqqqrYtWtXtGZMPnpuwnd/VOL4/hTBEBID3LMciter5tWUGXpaOeGIWijl5eU0NjbGPIa9fft2KisrB68D+8EKIfR3wsV/949YnQwfzp25JLh/lSO2DRSEkYlKKBUVFRw9epT6+vqwXcBzc3MZGBigo6MjrFZpa2sjNzd32LJsNhs2my0aMyY2Az1qc7dva9UeVqHLZXMXqJrjgXUwbZZuJk4mxiUUTdPYsmULtbW1nDx5ktmzZ4fdX7x4MRaLhRMnTgwGrjU1NdHc3ExpaWn8rJ6ouPvh8nE1lPvXY+GLnmYUqZqjeD3MmKufjZOUcQmlvLycAwcOcOTIEex2+2C/IzMzk/T0dDIzM9m0aROVlZVkZWXhcDjYsmULpaWlMuI1El43XPkSvj2k9s4d6A7emzZbCaN4A2TPT+qJwInOuITyzjvvAAyZBd2/fz/PPvssANXV1RiNRjZs2BA24SiE4POqjnjjp6pj3ncreM9xt2pSFW9Q++eKOJKCcTe9xiItLY2amhpqamqiNmpC4vPBj2eUOL49DD3twXtT7gqKY2YJJGjx0URgxYoVLFq0iD179vyqz5VYr0SiadDyv35x1ELXT8F76dNg3j8qccx6OKU2WpiMiFDijaZB+4VgfNWtkBlwqx3mrVbimLMiuKm0kPSIUOLFjcv+muMQXL8YTDenQ9HvVaf8vsfVptJCTHg8HioqKvjoo4+wWCy8+OKLvPbaawnd+VKEEgu3flDCaDwErf8XTDdZYe5K1e/4zRNqa9BkJ7AHsB6Mc1HYhx9+yKZNmzhz5gxff/01mzdvprCwkOeffz5hJopQxkvXz8H4qh//J5huNMOcv1c1x/1PqqjcVMLdC/+Wr8+z/6VFLRKLkIKCAqqrqzEYDBQVFfHNN99QXV0tQtGdnhtwIXB45p8Ji6+a/Qg8sF51zKck0REKE5hly5aFNbNKS0vZvXs3Xq83bids3YkIZST6OuCi//DMv9UNPTwzEHxoHz40J+WwZKg3u17PTnJEKKG4boccnvmn8LM68hap0aoH1sXl8Mykw2AYV/NHT7766quw64aGBubOnZuw2gREKOqcjkufK3H89fPwHdez5/uDD9fD9Hv1s1EIo7m5mcrKSl544QXOnTvH3r172b17d0KfOTmF4hmAK18ocTT9BwzcDt7LujcYfJg9Tz8bhRF55pln6Ovro6SkBJPJxMsvv8zmzZsT+szJIxSvB76v98dXfabWeATILAgGH+YukPiqJObkyZOD/wdiD38NJrZQfD5oPq3mOr49DL03gvem5vrjq9arxU8iDmEUJp5QNA1+OheMr+oOGcnJmK5Gqh5YD/c8JPFVQsRMDKFomjqfIxBf1fFD8J4tE+atgeJ1MPt3El8lREVqC+V6kxJG46dw81Iw3TLFH1+1Ae77BzDLUmMhNlJPKL9cDcZXtTUG0002+M1KJY65q8Ca/JNYepPo3RWTgXh9x9QRis8HH672h5D4MVrg3sf8m7v9Xp0yK4yJxaKan729vaSnp+tsTWLp7VWBnoHvHC2pIxSjUS12Mhhh9qP+zd1WQ0aW3palHCaTCafTSXu7WmWZkZGR0BB1PdA0jd7eXtrb23E6nTHP2qeOUAAefw1WV8PUbL0tSXkC20cFxDJRcTqdI26VNR5SSygSRhI3DAYDeXl5ZGdn43a7x/5ACmKxWOIW/5VaQhHijslkSmgw4URBtvsQhAgQoQhCBIhQBCECRCiCEAEiFEGIABGKIESACEUQIkCEIggRIEIRhAgQoQhCBIhQBCECJNZLmJD4fBoDXh/9bi/9bh9ZU6xYzdHXCyIUIeF4fRouj3JY5bheXJ6gE/d7vLjcPn8elRaeP+Ta48U1XB5/Gep/HwMeX5gNf6xYzoKZzqi/gwhlkuHx+uj3DO+wrlCHC3HCMKf2XwfyDnXqQP5gHrdX3yXHZqNhiHDGXUacbBHGiaZpuL2a39lC36jDvEWHcWBXmAOHv5lHzOPx4fXp67QWk4E0swmbxUSaxYjNbCTNYvL/Gf33jHfk8d+zmEgzGwfT08zqc7bQNP/1YJlmI2ZT7F1xEQrKaV0eX/BNOcTphnu7hr5Zwx023MGHd2qXx4vOPovVbCQtxKmCDmYMd0DzcE4Yfh1w5jCnviO/zWzCZEzNJccJE0pNTQ1vvPEGra2tLFy4kL1791JSUhJTmd/82Mmt3oFBBwxz1uGc2RN+PZIIXB4fem9IEnxjBt+oaRblqHe+IUd16tC37h1v61AntpqMGFPUafUgIUL5+OOPqays5N1332Xp0qXs2bOHVatW0dTURHZ29Ovd//XwN/zlx86xM8aAwUDYGzT8zWoc1ulCndM2yht6JBHYzMYJt7nDRMOgJWBzp6VLl7JkyRLeeustAHw+HwUFBWzZsoVt27aN+tmuri4yMzPp7OzE4QjffuiVj89zsbV7SFt2SDNgmPbu8A6urm0hjmwxGcRpJwmj+dqdxL1GGRgY4OzZs2zfvn0wzWg0UlZWxunTp4fkd7lcuFyuweuurq4Ry65+alFcbRWESIm7UG7cuIHX6yUnJycsPScnh4sXLw7JX1VVxa5du4akjyYYQYgHAR+LpFGl+6jX9u3bqaysHLz+6aefmD9/PgUFE/D4NyEp6e7uJjNz9FOc4y6UGTNmYDKZaGtrC0tva2sbdiMym82GzRbcRHvq1Klcu3YNu90+pK/Q1dVFQUEB165dG7NNOdmQ32Z4RvtdNE2ju7ub/Pyxjw2Pu1CsViuLFy/mxIkTrF27FlCd+RMnTlBRUTHm541GIzNnzhw1j8PhEGcYAflthmek32WsmiRAQppelZWVbNy4kQcffJCSkhL27NlDT08Pzz33XCIeJwgJJyFCeeqpp7h+/To7duygtbWVRYsWcezYsSEdfEFIFRLWma+oqIioqTUebDYbO3fuDOvTCAr5bYYnXr9LQiYcBWGiISscBSECRCiCEAEiFEGIABGKIESACEUQIiClhFJTU8OsWbNIS0tj6dKlnDlzRm+TdKe+vp41a9aQn5+PwWDg8OHDepuUFFRVVbFkyRLsdjvZ2dmsXbuWpqamqMtLGaEEFoPt3LmTc+fOsXDhQlatWjXhD+sci56eHhYuXEhNTY3epiQVdXV1lJeX09DQwPHjx3G73axcuZKenp7oCtRShJKSEq28vHzw2uv1avn5+VpVVZWOViUXgFZbW6u3GUlJe3u7Bmh1dXVRfT4lapTAYrCysrLBtNEWgwnCnXR2qiXkWVlZUX0+JYQy2mKw1tZWnawSUgWfz8fWrVtZvnw5xcXFUZWh+8ItQUg05eXlNDY2curUqajLSAmhjHcxmCAEqKio4OjRo9TX14+5zmk0UqLpFboYLEBgMVhpaamOlgnJiqZpVFRUUFtbyxdffMHs2bNjKi8lahSQxWAjcfv2bS5fvjx4ffXqVc6fP09WVhaFhYU6WqYv5eXlHDhwgCNHjmC32wf7spmZmaSnp4+/wPgOwiWWvXv3aoWFhZrVatVKSkq0hoYGvU3SnS+//FIDhvxt3LhRb9N0ZbjfBND2798fVXmyHkUQIiAl+iiCoDciFEGIABGKIESACEUQIkCEIggRIEIRhAgQoQhCBIhQBCECRCiCEAEiFEGIABGKIETA/wP4fpn0CIAPxwAAAABJRU5ErkJggg==",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAH0AAAB4CAYAAADfTf2WAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjkuMSwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/TGe4hAAAACXBIWXMAAA9hAAAPYQGoP6dpAAAOP0lEQVR4nO2dbWxTV5rHf7ZjJ3bjl7zgkFAH6E63bJUFJEhChunSWWVAK7VaKNJ2+6VVhcpu6yDAH3bKSgV1Pmyk5QOMaNRO0ZZWGrV00YpBZUYdsWEJYoeUBdQKNuClzKhJCU54sx3id/vshxObmKRJHNvxy70/6So5J+ee89z7zzn33HOec65GCCFQURTaQhugsvCooisQVXQFooquQFTRFYgqugJRRVcgFYU24HESiQTDw8OYzWY0Gk2hzSkZhBCMjY3R1NSEVjtzXS460YeHh3E4HIU2o2QZGhriySefnDFN0YluNpsBabzFYimwNaWD3+/H4XCk7t9MFJ3oySbdYrGoos/E2Ai4fwdrX0+LnssjsehEV5kD//sbOLkbgvfB5oAfdWZ0uip6KRF8AL/7J7jy7zLc8Jdgbsw4G1X0UuHbXjjRBWPDoNHCT1yw4edQYcg4q7ISPR6PE41GC21GbokE4L9/if7ir9DFg1D7Z7DlV+BonXeWZSG6EAKPx4PX6y20KbklFobAfbD9GH66Flv8LovX/R2ayieyyrYsRE8KbrfbMZlMpT+oIxIwfgcCQbDaEJoKAvpaRh+MwX0/jY0KFz0ej6cEr6urK7Q52RMNwIPvIBaCCg0Ya8G6BKO2AvT3GB0dxW63o9Pp5l1EyYuefIabTKYCW5IlQsDDERjzAAK0FWB1gNGWSpK8xmg0qmzRk5R0kx4LydodDchwlVUKrtOnJcvVNZaN6CWJEBC4C75hIAEaHViXyCY9j//EquiFIhYB7yBExmTYUA22pfN6784UVfSFRgg5sub7HkQc0IKlCZ6oz2vtnowq+kISj4JvCEI+GdabZO3WVy2oGarnzEIR9MKd6xOCa8DcyJcX/8hPftqJzWajrq6OF154gZs3b+bdlLKr6UIIgtF4Qco26nVTe9iJGPhuyRkxgIoqWbsNJsYDAVwuFytXruThw4fs3buXLVu28PXXX8/q/ZINZSd6MBrn2b2/L0jZA7/YhMkw6ZaGx2RnLR6R4Wq7nBXTSEG3bt2adv5HH33EokWLGBgYoKWlJW92qs17PkjEZUft3rdScJ0B6p4Gy5KU4AA3btzglVde4amnnsJisbBs2TIABgcH82pe2dV0o17HwC82FaxsIuNyoCUelpGmetk7104dQXvxxRdZunQphw8fpqmpiUQiQUtLC5FIJK92lp3oGo0mvYldKEQCxm7LoVQArR5szVA1vcvXvXv3cLvdHD58mOeeew6Ac+fOLYipZSd6QYgGJyZJgjJcVQPWJ0H3w7e3pqaGuro6PvzwQxobGxkcHOTtt99eEHPVZ3o2JCdJ7ril4Bod1CyD2mUzCg6g1Wo5evQoly5doqWlhd27d7N///4FMTsj0bu7u2ltbcVsNmO329m8eTNutzstTSgUwul0UldXR3V1NVu3bmVkZCSnRhcFsTDcuwH+YUBApQXsfwHGmjln0dnZycDAAKFQiG+++YYNGzYghGDz5s15MxsyFL2vrw+n00l/fz+nTp0iGo2yceNGxsfHU2l2797NF198wbFjx+jr62N4eJiXXnop54YXDCFg/K4caImMy9641QG1T02ZFStaRBaMjo4KQPT19QkhhPB6vUKv14tjx46l0ly7dk0A4vz583PK0+fzCUD4fL45pQ8Gg2JgYEAEg8HMLyBTYmEh7n4rxK3L8rjzf0JEQ/kvd4KZrjWT+5ZVR87nk2PItbW1AFy6dIloNEpn5yM/7BUrVtDc3Mz58+dZt27dlDzC4TDhcDgV9vv92ZiUPwL3J02SaCYmSRYt2CRJLpl3Ry6RSLBr1y7Wr1+fGj3yeDwYDAZsNlta2oaGBjwez7T5dHd3Y7VaU0fRrWOLx+D+n8D7nRRcb4RFz8jRtRIUHLIQ3el0cvXqVY4ePZqVAXv27MHn86WOoaGhrPLLKSEf3LkGIa8MVy+G+j+Xwpcw82reu7q6OHnyJGfPnk1bIbl48WIikQherzetto+MjLB48eJp86qsrKSysnI+ZuSPRBz8tyBwT4YrKicmSbLzQi0WMqrpQgi6uro4fvw4p0+fZvny5Wl/X7NmDXq9nt7e3lSc2+1mcHCQjo6O3Ficb8IPZc88KfgTi6B+RdkIDhnWdKfTyaeffsqJEycwm82p57TVasVoNGK1Wtm2bRsul4va2losFgs7duygo6Nj2k5cUZGYGEYdH5VhnUEOo1bOvvS35MjklQGY9jhy5Ejaa8Vbb70lampqhMlkElu2bBG3b9+ecxkFeWULjwsxMvDoVezBd0LEY/PPL08U5JVNzGFH0aqqKnp6eujp6cn4H3DBEYkJX/MRUr7mtmbpgrwAPP/886xevZqDBw8uSHlJlDvhEg3J17CUr7ltwte8/G9J+V/h4wgh14klx8w1OjkjZqwp2ffuTFHWLFssLL1Z/LeQkyRmsK8AU34XF8xoUixGV1cXVquV+vp63nnnnTk9RrOh/Gq6EI+a7MlxwQdSbJGQkyTmRjDVSbfkeI7WtOtNGf/zfPLJJ2zbto0LFy5w8eJFtm/fTnNzM2+88UZubJqG8hM9GoB/aSpM2f88nPH7vMPh4MCBA2g0Gp555hmuXLnCgQMH8iq6spr3ImTdunVpbtMdHR3cuHGDeDx/btzlV9P1Jnh7UDblQa+MqzDKXZjyPWauL43l0uUnengMvEOQiEqRqxvAvDjN9biY+Oqrr9LC/f39PP3001mtP5+N4rwT8yERl2LfvykF11XKGTFLU9EKDtLH3eVy4Xa7+eyzzzh06BA7d+7Ma5nlUdNjYTnnrZ3ohT+xSPbOp/E1LzZeffVVgsEgbW1t6HQ6du7cyfbt2/NaZmmLHgvDH94D40qw1su13TVLS2aS5MyZM6nf33///QUrt3jbvdnwXIHDfw2XP0YOtFjlQEuJCF5ISq+mx2Pwh1/Cf3XLZ3f9StmcW5fICROVWSmtu3TvJhz/B/j+f2R4xQvws/0w6iusXSVGaYieSMDFf4NTe+WIW6UF/uZfYdXfQzgMqKJnQvGL7vseTjjhj2dkePkG+NseOdgyiXxPUhQDubrG4hb9+m/h+JsQ9slRtZ+9C61vwKRdGvR6uaokEAhgNJa2l+psBAJyIil5zfOluEU31cstt5aslTsf1/9oShKdTofNZmN0VPq2lcXesI8hhCAQCDA6OorNZst6tK64RW9uh1dPQPOPZ/RoSbpXJ4UvV2w22w+6kmdCcYsOsPyvZk2i0WhobGzEbreX337vE+j1+pyNxxe/6Bmg0+nyOlFRLpTuiJzKvFFFVyCq6ApEFV2BqKIrEFV0BaKKrkBU0RWIKroCUUVXIKroCkQVvQQRQvAwHOOWN0g4lvnyp7KacCk1IrEEvmAUXzCCLxjFG4im/Uwe3sDE34NR/BN/jyWkF81vnOtZ7bBlVK4qepYkEoKxcAxfUrDHBPQFo/gC08cHItktUjTotATCsYzPU0WfIBSNT6ppU2tWMixFjKR+9wejJLJwXdNowFxZgc1kwGbSYzU+OpJhm9GAZXLYJOOq9Np5eQmVleixeAJ/KJYm3KMm8vGm81HN8wajRGKJrMqu0muxGQ1SsJRYk8QzGabGGfWYq/TotAvr3pU30Xt6eti/fz8ej4dVq1Zx6NAh2traMsrjwXiEax5/qrZ5Jwnon6YpHQtl3tRNRqfVpNW09Nqmx5KKM0zUNhm2GPVU6UvHeSMvon/++ee4XC4++OAD2tvbOXjwIJs2bcLtdmO32+ecz1d/usc//vpyxuVXV1ZMK5x1ollMi5uUprqyouycKqdDI/LgMN7e3k5rayvvvfceIHeMdjgc7NixY9bvlPj9fqxWKz6fjxsPYvz8P648ahYnPeOsRvkcfLw5tRj16HXKexOdfN8sluk/FpQk5zU9Eolw6dIl9uzZk4rTarV0dnZy/vz5Keln2u99zdJa/tO1IdcmKp6ci3737l3i8TgNDQ1p8Q0NDVy/fn1K+u7ubt59990p8UW72X+Rkrxfc2m4C95737NnDy6XKxW+desWzz77bPFt9l8ijI2NYbXOvM1pzkWvr69Hp9NN+ULTD+35/vh+79XV1QwNDWE2m9FoNPj9fhwOB0NDQ7M+q5TE4/dFCMHY2BhNTbNvp5Zz0Q0GA2vWrKG3tzf1qalEIkFvby9dXV2znq/VatM+HJDEYrGook/D5PsyWw1Pkpfm3eVy8dprr7F27Vra2to4ePAg4+PjvP766/koTiVD8iL6yy+/zJ07d9i7dy8ej4fVq1fz5ZdfTuncqRSI3G1Bnx9CoZDYt2+fCIUW7vtnpUA29yUvgzMqxY3yhq5UVNGViCq6AlFFVyCq6AqkqEXv6elh2bJlVFVV0d7ezoULFwptUsHp7u6mtbUVs9mM3W5n8+bNuN3ujPIoWtGTjhj79u3j8uXLrFq1ik2bNpX9ZkKz0dfXh9PppL+/n1OnThGNRtm4cSPj4+NzzyTnowY5oq2tTTidzlQ4Ho+LpqYm0d3dXUCrio/R0VEBiL6+vjmfU5Q1PemI0dnZmYqbyRFDyfh8covU2traOZ9TlKLP5IiR/Kivipy93LVrF+vXr6elpWXO5xXciUJl/jidTq5evcq5c+cyOq8oRc/UEUOJdHV1cfLkSc6ePTut/8FMFGXzPtkRI0nSEaOjo6OAlhUeIQRdXV0cP36c06dPs3z58nllUpQcPXpUVFZWio8//lgMDAyI7du3C5vNJjweT6FNKyhvvvmmsFqt4syZM+L27dupIxAIzDmPohVdCCEOHTokmpubhcFgEG1tbaK/v7/QJhUcYNrjyJEjc85DnU9XIEX5TFfJL6roCkQVXYGooisQVXQFooquQFTRFYgqugJRRVcgqugKRBVdgfw/8e8S1MN+j9oAAAAASUVORK5CYII=",
       "text/plain": [
-       "<Figure size 200x100 with 1 Axes>"
+       "<Figure size 100x100 with 1 Axes>"
       ]
      },
      "metadata": {},
@@ -205,7 +214,7 @@
     }
    ],
    "source": [
-    "df.plot(figsize=(2, 1))"
+    "df.plot(figsize=(1, 1))"
    ]
   },
   {


### PR DESCRIPTION
Close #101

Sets up 16 ANSI colors as in my jellyfish theme for dark mode (I know they're not optimal either haha but at least now easily configurable), and GitHub's notebook viewer for light mode:

<img width="424" alt="image" src="https://github.com/user-attachments/assets/30ae22b4-a1ac-45dd-9b53-873c3c5cb9b4" />
<img width="421" alt="image" src="https://github.com/user-attachments/assets/d8be4b9b-0823-4a3d-88db-f2d2fb685c70" />

One caveat is that quite a few of the colors (e.g. function names, string literals) used in the exception traces are actually from the 256 ANSI colors so while it's better than before, it's still hard to read in dark mode :(

<img width="616" alt="image" src="https://github.com/user-attachments/assets/fa739db7-6f9c-401c-bebb-ae72514d62fa" />

I'll note that the above output was produced by using Jupyviv. If I run the same thing in a Jupyter Lab instead and then render the notebook with Vivify, it looks like this:

<img width="614" alt="image" src="https://github.com/user-attachments/assets/5ef36312-ba2b-4c83-ab6a-0685301c9d64" />

For reference, this is how the Jupyter Lab-executed notebook renders on Vivify before this PR:

<img width="615" alt="image" src="https://github.com/user-attachments/assets/e0f738ce-73c7-44ed-82b2-315c05a49be0" />

Seems like Jupyter Lab somehow makes the kernel use just the 16 colors. I'll check if I can somehow do this with Jupyviv as well, maybe by setting the `TERM` environment variable or something (→ https://github.com/jannis-baum/Jupyviv/issues/6)

Light mode looks good & readable, both when using the 16 colors as well as when using the 256 colors from Jupyviv


EDIT: Just realized that the Jupyter Lab version also still uses colors other than the 16. You can see it in the dark green `def`s for example, that color isn't one of the ones above