### PR TITLE
Issue/141 obsidian style callouts

### DIFF
--- a/src/parser/markdown.ts
+++ b/src/parser/markdown.ts
@@ -71,8 +71,10 @@ mdit.use(anchor, {
     }),
 });
 mdit.use(copycode);
+mdit.use(githubAlerts, {
+    markers: '*',
+});
 mdit.use(graphviz);
-mdit.use(githubAlerts);
 mdit.use(mermaid);
 mdit.use(wikiLinks);
 

--- a/static/colors.css
+++ b/static/colors.css
@@ -47,6 +47,8 @@
     --alert-warning: #ffaf00;
     --alert-caution: #ff5f5f;
 
+    --alert-custom-default: #c0c0c0;
+
     --ipynb-bg-error: rgba(255, 0, 0, 0.1);
     --ipynb-ansi-black: #616161;
     --ipynb-ansi-brblack: #8e8e8e;
@@ -118,6 +120,8 @@
         --alert-important: #8250df;
         --alert-warning: #bf8700;
         --alert-caution: #cf222e;
+
+        --alert-custom-default: #404040;
 
         --ipynb-bg-error: rgba(255, 0, 0, 0.1);
         --ipynb-ansi-black: #3e424d;

--- a/static/colors.css
+++ b/static/colors.css
@@ -47,8 +47,6 @@
     --alert-warning: #ffaf00;
     --alert-caution: #ff5f5f;
 
-    --alert-custom-default: #c0c0c0;
-
     --ipynb-bg-error: rgba(255, 0, 0, 0.1);
     --ipynb-ansi-black: #616161;
     --ipynb-ansi-brblack: #8e8e8e;
@@ -120,8 +118,6 @@
         --alert-important: #8250df;
         --alert-warning: #bf8700;
         --alert-caution: #cf222e;
-
-        --alert-custom-default: #404040;
 
         --ipynb-bg-error: rgba(255, 0, 0, 0.1);
         --ipynb-ansi-black: #3e424d;

--- a/static/markdown.css
+++ b/static/markdown.css
@@ -149,6 +149,14 @@ blockquote {
     vertical-align: text-bottom;
     fill: currentColor;
 }
+/* default style for custom markers (Obsidian Callout style) */
+.markdown-alert {
+    border-left: .25rem solid var(--alert-custom-default);
+}
+.markdown-alert .markdown-alert-title {
+    color: var(--alert-custom-default);
+}
+/* default styles for GitHub style markers */
 .markdown-alert-note {
     border-left: .25rem solid var(--alert-note);
 }

--- a/static/markdown.css
+++ b/static/markdown.css
@@ -149,12 +149,12 @@ blockquote {
     vertical-align: text-bottom;
     fill: currentColor;
 }
-/* default style for custom markers (Obsidian Callout style) */
+/* default style for unconfigured custom markers (Obsidian Callout style) */
 .markdown-alert {
-    border-left: .25rem solid var(--alert-custom-default);
+    border-left: .25rem solid var(--alert-note);
 }
 .markdown-alert .markdown-alert-title {
-    color: var(--alert-custom-default);
+    color: var(--alert-note);
 }
 /* default styles for GitHub style markers */
 .markdown-alert-note {

--- a/tests/rendering/markdown-additional.md
+++ b/tests/rendering/markdown-additional.md
@@ -52,11 +52,13 @@ While not a markdown syntax, this has a default style:
 
 Press <kbd>Ctrl</kbd> + <kbd>C</kbd> to copy, and <kbd>Ctrl</kbd> + <kbd>V</kbd> to paste!
 
-## Custom attributes
+## Custom attribute
 
 This paragraph has a red background color.{style=background-color:red}
 
-## Github alert blockquote
+## GitHub style alert
+
+### The 5 default GitHub style alerts
 
 > [!NOTE]  
 > Something to take into account
@@ -73,7 +75,18 @@ This paragraph has a red background color.{style=background-color:red}
 > [!CAUTION]
 > Do not do this and that!
 
-With a custom title:
+### With a custom title
 
 > [!NOTE] Foo bar
-> Hello
+> 'Note' with a custom title
+
+### Using custom markers ([Obsidian Callout](https://help.obsidian.md/Editing+and+formatting/Callouts) style)
+
+> [!CUSTOM]
+> Something more special
+
+> [!fOoBaR]
+> The marker is case-insensitive and turns into Title Case
+
+> [!CUSTOM] paY aTtEntiOn
+> You can use a custom title with a custom marker as well

--- a/tests/rendering/markdown-additional.md
+++ b/tests/rendering/markdown-additional.md
@@ -77,13 +77,15 @@ This paragraph has a red background color.{style=background-color:red}
 
 ### With a custom title
 
-> [!NOTE] Foo bar
-> 'Note' with a custom title
+> [!TIP] Foo bar
+> 'Tip' with a custom title
 
 ### Using custom markers ([Obsidian Callout](https://help.obsidian.md/Editing+and+formatting/Callouts) style)
 
 > [!CUSTOM]
-> Something more special
+> Set custom icon and color for any marker
+>
+> If unconfigured, it's styled like 'Note'
 
 > [!fOoBaR]
 > The marker is case-insensitive and turns into Title Case


### PR DESCRIPTION
Issue: #141

I'd accidentally removed this branchfrom my fork, which adds everything other than custom icons support, which is the main thing this is stuck on. Let's re-add, this time opening a draft PR.

Problems:

Icons need to be able to be able to be specified 3 different ways:
1. octicons
2. inline svg
3. svg from file

The idea is to do that configuration in `config.json`.

It's possible to customize the icons in the GH Alerts plugin itself:

https://github.com/antfu/markdown-it-github-alerts/blob/f2bcca68854891e13e7df77420734ac8cce6ebae/src/index.ts#L16-L22

But there was a problem where setting any custom icons would discard the defaults for the 5 default GH Alert icons (todo: re-confirm, was this the case?).