### PR TITLE
Add missing semicolon to makefile cleanup on node SEA error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,7 +76,7 @@ $(SERVER_PATH_LINUX): $(BUNDLE_PATH) sea-config.json
 		{ \
 		printf "\n\n\x1b[1;31mYour $(shell command -v node) does not support Node SEA, which is needed to compile Vivify.\x1b[0m\n"; \
 		printf "\x1b[1;31mPlease install Node.js through Node Version Manager (nvm) and try again.\x1b[0m\n"; \
-		rm $(SERVER_PATH_LINUX) \
+		rm $(SERVER_PATH_LINUX); \
 		exit 1; \
 		}
 	chmod +w $(SERVER_PATH_LINUX)


### PR DESCRIPTION
Hey Jannis, I notice this. Missing a semi-colon here, so `rm` tries to remove `vivify-server` and then also a file called `exit` and a file called `1`

Let me know it you want me to make an issue for this.

