### PR TITLE
Improve symlinks in directory viewer

### DIFF
--- a/src/parser/parser.ts
+++ b/src/parser/parser.ts
@@ -1,4 +1,4 @@
-import { Dirent, readlinkSync, realpathSync } from 'fs';
+import { Dirent, readlinkSync, existsSync } from 'fs';
 import { homedir } from 'os';
 import { join as pjoin, dirname as pdirname, basename as pbasename } from 'path';
 import { pathToURL } from '../utils/path.js';
@@ -59,27 +59,22 @@ export function renderTextFile(content: string, path: string): string {
 }
 
 function dirListItem(item: Dirent, path: string): string {
-    let itemClass = '';
-    let icon = '';
-    let fullPath = '';
     if (item.isSymbolicLink()) {
-        itemClass = "dir-list-symboliclink";
-        icon = linkIcon;
-        fullPath = pjoin(path, readlinkSync(pjoin(path, item.name)));
-    } else if (item.isDirectory()) {
-        itemClass = "dir-list-directory";
-        icon = dirIcon;
-        fullPath = pjoin(path, item.name);
+        const targetPath = readlinkSync(pjoin(path, item.name));
+        const isVaild = existsSync(pjoin(path, targetPath));
+        return `<li class="dir-list-symboliclink" name="${item.name}">
+                    <a href="${isVaild ? pathToURL(pjoin(path, targetPath)) : ''}">
+                        ${linkIcon}${item.name} ->&nbsp;
+                        <span style="color: ${isVaild ? "#55ff55" : "#ff0000" }">${targetPath}</span>
+                    </a>
+                </li>`;
     } else {
-        itemClass = "dir-list-file";
-        icon = fileIcon;
-        fullPath = pjoin(path, item.name);
+        return `<li class="dir-list-${item.isDirectory() ? 'directory' : 'file'}" name="${item.name}">
+                    <a href="${pathToURL(pjoin(path, item.name))}">
+                        ${item.isDirectory() ? dirIcon : fileIcon}${item.name}
+                    </a>
+                </li>`;
     }
-    return `<li class="${itemClass}" name="${item.name}">
-        <a href="${pathToURL(fullPath)}">
-            ${icon}${item.name}
-        </a>
-    </li>`;
 }
 
 function dirUpItem(path: string): string {

--- a/static/style.css
+++ b/static/style.css
@@ -54,6 +54,7 @@ li[class^='dir-list-'] > a:hover {
 li[class^='dir-list-'] > a > svg {
     margin-right: 0.3rem;
 }
+li[class^='dir-list-symboliclink'] > a { color: var(--text-link); }
 .icon-directory { fill: var(--icon-directory); }
 .icon-file { fill: var(--icon-file); }
-.icon-symlink { fill: var(--icon-file); }
+.icon-symlink { fill: var(--text-link); }

--- a/static/style.css
+++ b/static/style.css
@@ -56,3 +56,4 @@ li[class^='dir-list-'] > a > svg {
 }
 .icon-directory { fill: var(--icon-directory); }
 .icon-file { fill: var(--icon-file); }
+.icon-symlink { fill: var(--icon-file); }


### PR DESCRIPTION
Hi team,

A work-in-progress draft PR for the symbolic link implementation in the directory view renderer.

I haven't checked yet, but there should be one line that fails Prettier linting, that has some hard coded color values that will need to be moved to the colors.css anyway (once we pick nicer colors). 

This is all i have for today, @tuurep if you want to play with it you are welcome 😋