### PR TITLE
docs: mention Nix package

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,9 @@ directory as an argument! See below for installation options.
   (maintained by [@jannis-baum](https://github.com/jannis-baum))
 - `yay -S vivify` for [AUR](https://aur.archlinux.org/packages/vivify)
   (maintained by [@tuurep](https://github.com/tuurep))
+- `nix-shell -I nixpkgs=channel:nixos-unstable -p vivify`
+   for [Nixpkgs](https://search.nixos.org/packages?channel=unstable&query=vivify)
+  (maintained by [@skohtv](https://github.com/skohtv))
 
 ### Manual
 


### PR DESCRIPTION
Vivify's Nix package got merged into Nixpkgs (https://github.com/NixOS/nixpkgs/pull/437546) 🎉

It's currently available on the **unstable** branch, and will be available on **stable** for the next release (25.11, in late November).

There's a lot of ways to install a package on Nix(OS), I kept it simple by just giving the interactive shell syntax, I think there's no need for a whole section.

The package can be used through `nix-shell -I nixpkgs=channel:nixos-unstable -p vivify`.
The command will be simpler once it reaches stable.

Note: I've currently only implemented it for `x86_64-linux` as it's my daily driver, but I'm working on adding it to `aarch64-linux`, `x86_64-darwin` and `aarch64-darwin`.