### PR TITLE
docs: add micro integration plugin to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ list!
 #### Existing integration
 
 - for Vim and Neovim: [vivify.vim](https://github.com/jannis-baum/vivify.vim)
+- for micro: [micro-vivify](https://codeberg.org/gibbert/micro-vivify)
 
 ## Installation
 


### PR DESCRIPTION
I made a Vivify plugin for [micro](https://micro-editor.github.io/), you can have a look at it [here](https://codeberg.org/gibbert/micro-vivify). This PR adds a mention about it in the README.