### PR TITLE
Fix TypeScript loader

### DIFF
--- a/loader.mjs
+++ b/loader.mjs
@@ -1,0 +1,4 @@
+import { register } from 'node:module';
+import { pathToFileURL } from 'node:url';
+
+register('ts-node/esm', pathToFileURL('./'));

--- a/package.json
+++ b/package.json
@@ -3,11 +3,11 @@
   "repository": "https://github.com/jannis-baum/vivify.git",
   "author": "Jannis Baum",
   "scripts": {
-    "dev": "VIV_TIMEOUT=0 VIV_PORT=3000 NODE_ENV=development nodemon --ignore tests/rendering/symlinks --exec node --loader ts-node/esm src/app.ts",
-    "viv": "VIV_PORT=3000 node --loader ts-node/esm src/app.ts",
+    "dev": "VIV_TIMEOUT=0 VIV_PORT=3000 NODE_ENV=development nodemon --ignore tests/rendering/symlinks --exec node --import ./loader.mjs src/app.ts",
+    "viv": "VIV_PORT=3000 node --import ./loader.mjs src/app.ts",
     "lint": "eslint src static",
     "lint-markdown": "markdownlint-cli2 --config .github/.markdownlint-cli2.yaml",
-    "test": "node --loader ts-node/esm --test tests/unit/cli.ts tests/unit/alerts.ts",
+    "test": "node --import ./loader.mjs --test tests/unit/cli.ts tests/unit/alerts.ts",
     "deduplicate": "yarn-deduplicate"
   },
   "type": "module",


### PR DESCRIPTION
Close #295

`node --loader` was deprecated in Node 25 which broke the tests & dev setup. i tried to look for some convention to follow here but couldn't find anything, it's all a mess. the way it is now is whatever copilot came up with🙃